### PR TITLE
Fix for: private method `row_position=' called

### DIFF
--- a/spec/duck-model/duck_spec.rb
+++ b/spec/duck-model/duck_spec.rb
@@ -25,9 +25,9 @@ describe Duck do
     }
     @ducks.each { |name, duck|
       duck.reload
-      duck.row_position = 0
-      duck.size_position =  0
-      duck.age_position = 0
+      duck.update_attribute :row_position, 0
+      duck.update_attribute :size_position, 0
+      duck.update_attribute :age_position, 0
       duck.save!
     }
     @ducks.each {|name, duck| duck.reload }


### PR DESCRIPTION
Running the spec suite with Ruby 1.9.2-p180 produced above error message, leading to 15 test failures

This commit works around this issue by using "update_attribute"
