### PR TITLE
Add the first record in the middle of the valid position range

### DIFF
--- a/lib/ranked-model/ranker.rb
+++ b/lib/ranked-model/ranker.rb
@@ -74,7 +74,7 @@ module RankedModel
             if !current_order.empty? && current_order.last.rank
               rank_at( ( RankedModel::MAX_RANK_VALUE + current_order.last.rank ) / 2 )
             else
-              rank_at RankedModel::MAX_RANK_VALUE
+              rank_at( RankedModel::MAX_RANK_VALUE / 2 )
             end
           when String
             position_at position.to_i


### PR DESCRIPTION
This adjustment avoids a lot of calls to rebalance_ranks, especially when adding/moving records to the :last position. 

Without this adjustment every new element appended to a collection forces a call to the rebalance_ranks method since MAX_RANK_VALUE as position is already in use.
