### PR TITLE
Treat a "nil" position as equivalent to :last

### DIFF
--- a/lib/ranked-model/ranker.rb
+++ b/lib/ranked-model/ranker.rb
@@ -36,7 +36,7 @@ module RankedModel
       end
 
       def position
-        instance.send "#{ranker.name}_position"
+        instance.send( "#{ranker.name}_position" ) || :last
       end
 
       def rank

--- a/spec/duck-model/duck_spec.rb
+++ b/spec/duck-model/duck_spec.rb
@@ -124,4 +124,18 @@ describe Duck do
 
   end
 
+  describe "default to :last positioning" do
+    before {
+      @ducks[:curly] = Duck.create(:name => "Curly", :pond => "Stooges")
+      @ducks[:larry] = Duck.create(:name => "Larry", :pond => "Stooges")
+      @ducks[:moe]   = Duck.create(:name => "Moe", :pond => "Stooges")
+    }
+
+    subject { Duck.where(:pond => "Stooges").rank(:row).all }
+
+    its(:first) { should == @ducks[:curly] }
+
+    its(:last) { should == @ducks[:moe] }
+  end
+
 end


### PR DESCRIPTION
With this patch a nil value for the position record is treated as a :last position. This complements the logic that '0' represents :first

Since *_position need to be an integer column and :last is not a valid default value for such a column treating nil as an indication to append to the end of the collection seems a sensible way to deal with this situation
