### PR TITLE
STI support

### DIFF
--- a/lib/ranked-model/ranker.rb
+++ b/lib/ranked-model/ranker.rb
@@ -4,11 +4,12 @@ module RankedModel
   class InvalidField < StandardError; end
 
   class Ranker
-    attr_accessor :name, :column, :scope, :with_same
+    attr_accessor :name, :column, :scope, :with_same, :class_name
 
     def initialize name, options={}
       self.name = name.to_sym
       self.column = options[:column] || name
+      self.class_name = options[:class_name]
 
       [ :scope, :with_same ].each do |key|
         self.send "#{key}=", options[key]
@@ -30,7 +31,7 @@ module RankedModel
       end
       
       def validate_ranker_for_instance!
-        if ranker.scope && !instance.class.respond_to?(ranker.scope)
+        if ranker.scope && !instance_class.respond_to?(ranker.scope)
           raise RankedModel::InvalidScope, %Q{No scope called "#{ranker.scope}" found in model}
         end
 
@@ -47,7 +48,7 @@ module RankedModel
       def update_rank! value
         # Bypass callbacks
         #
-        instance.class.where(:id => instance.id).update_all ["#{ranker.column} = ?", value]
+        instance_class.where(:id => instance.id).update_all ["#{ranker.column} = ?", value]
       end
 
       def position
@@ -65,6 +66,10 @@ module RankedModel
       end
 
     private
+
+      def instance_class
+        ranker.class_name.nil? ? instance.class : ranker.class_name.constantize
+      end
 
       def position_at value
         instance.send "#{ranker.name}_position=", value
@@ -129,14 +134,14 @@ module RankedModel
 
       def rearrange_ranks
         if current_last.rank < (RankedModel::MAX_RANK_VALUE - 1) && rank < current_last.rank
-          instance.class.
-            where( instance.class.arel_table[:id].not_eq(instance.id) ).
-            where( instance.class.arel_table[ranker.column].gteq(rank) ).
+          instance_class.
+            where( instance_class.arel_table[:id].not_eq(instance.id) ).
+            where( instance_class.arel_table[ranker.column].gteq(rank) ).
             update_all( "#{ranker.column} = #{ranker.column} + 1" )
         elsif current_first.rank > RankedModel::MIN_RANK_VALUE && rank > current_first.rank 
-          instance.class.
-            where( instance.class.arel_table[:id].not_eq(instance.id) ).
-            where( instance.class.arel_table[ranker.column].lt(rank) ).
+          instance_class.
+            where( instance_class.arel_table[:id].not_eq(instance.id) ).
+            where( instance_class.arel_table[ranker.column].lt(rank) ).
             update_all( "#{ranker.column} = #{ranker.column} - 1" )
           rank_at( rank - 1 )
         else
@@ -168,19 +173,19 @@ module RankedModel
 
       def finder
         @finder ||= begin
-          _finder = instance.class
+          _finder = instance_class
           if ranker.scope
             _finder = _finder.send ranker.scope
           end
           if ranker.with_same
             _finder = _finder.where \
-              instance.class.arel_table[ranker.with_same].eq(instance.attributes["#{ranker.with_same}"])
+              instance_class.arel_table[ranker.with_same].eq(instance.attributes["#{ranker.with_same}"])
           end
           if !new_record?
             _finder = _finder.where \
-              instance.class.arel_table[:id].not_eq(instance.id)
+              instance_class.arel_table[:id].not_eq(instance.id)
           end
-          _finder.order(instance.class.arel_table[ranker.column].asc).select([:id, ranker.column])
+          _finder.order(instance_class.arel_table[ranker.column].asc).select([:id, ranker.column])
         end
       end
 
@@ -204,7 +209,7 @@ module RankedModel
         @current_last ||= begin
           if (ordered_instance = finder.
                                    except( :order ).
-                                   order( instance.class.arel_table[ranker.column].desc ).
+                                   order( instance_class.arel_table[ranker.column].desc ).
                                    first)
             RankedModel::Ranker::Mapper.new ranker, ordered_instance
           end

--- a/spec/duck-model/duck_spec.rb
+++ b/spec/duck-model/duck_spec.rb
@@ -38,13 +38,17 @@ describe Duck do
         :pond => 'Meddybemps' ),
       :beaky => Duck.create(
         :name => 'Beaky',
-        :pond => 'Great Moose' )
+        :pond => 'Great Moose' ),
+      :huey => Duckling.create(
+        :name => 'Huey',
+        :pond => 'Duckburg' )
     }
     @ducks.each { |name, duck|
       duck.reload
       duck.update_attribute :row_position, 0
       duck.update_attribute :size_position, 0
       duck.update_attribute :age_position, 0
+      duck.update_attribute :sti_row_position, 0
       duck.save!
     }
     @ducks.each {|name, duck| duck.reload }
@@ -90,16 +94,33 @@ describe Duck do
       @ducks[:beaky].update_attribute :row_position, 0
       @ducks[:webby].update_attribute :row_position, 2
       @ducks[:waddly].update_attribute :row_position, 2
-      @ducks[:wingy].update_attribute :row_position, 6
+      @ducks[:wingy].update_attribute :row_position, 7
     }
 
     subject { Duck.rank(:row).all }
 
-    its(:size) { should == 6 }
+    its(:size) { should == 7 }
     
     its(:first) { should == @ducks[:beaky] }
     
     its(:last) { should == @ducks[:wingy] }
+
+  end
+
+  describe "sorting by sti row" do
+
+    before {
+      @ducks[:huey].update_attribute :sti_row_position, 0
+      @ducks[:beaky].update_attribute :sti_row_position, 7
+    }
+
+    subject { Duck.rank(:sti_row).all }
+
+    its(:size) { should == 7 }
+
+    its(:first) { should == @ducks[:huey] }
+
+    its(:last) { should == @ducks[:beaky] }
 
   end
 
@@ -111,15 +132,15 @@ describe Duck do
       @ducks[:webby].update_attribute :row_position, 2
       @ducks[:wingy].update_attribute :size_position, 1
       @ducks[:waddly].update_attribute :row_position, 2
-      @ducks[:wingy].update_attribute :row_position, 6
-      @ducks[:webby].update_attribute :row_position, 6
+      @ducks[:wingy].update_attribute :row_position, 7
+      @ducks[:webby].update_attribute :row_position, 7
     }
 
     describe "row" do 
 
       subject { Duck.rank(:row).all }
 
-      its(:size) { should == 6 }
+      its(:size) { should == 7 }
       
       its(:first) { should == @ducks[:beaky] }
       

--- a/spec/ranked-model/ranker_spec.rb
+++ b/spec/ranked-model/ranker_spec.rb
@@ -5,14 +5,16 @@ describe RankedModel::Ranker, 'initialized' do
   subject {
     RankedModel::Ranker.new \
       :overview,
-      :column    => :a_sorting_column,
-      :scope     => :a_scope,
-      :with_same => :a_column
+      :column     => :a_sorting_column,
+      :scope      => :a_scope,
+      :with_same  => :a_column,
+      :class_name => 'Duckling'
   }
 
   its(:name) { should == :overview }
   its(:column) { should == :a_sorting_column }
   its(:scope) { should == :a_scope }
   its(:with_same) { should == :a_column }
+  its(:class_name) { should == 'Duckling' }
 
 end

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -12,8 +12,10 @@ ActiveRecord::Base.establish_connection('development')
 
 ActiveRecord::Schema.define :version => 0 do
   create_table :ducks, :force => true do |t|
+    t.string :type
     t.string :name
     t.integer :row
+    t.integer :sti_row
     t.integer :size
     t.integer :age
     t.string :pond
@@ -38,9 +40,13 @@ class Duck < ActiveRecord::Base
   ranks :row
   ranks :size, :scope => :in_shin_pond
   ranks :age, :with_same => :pond
+  ranks :sti_row, :class_name => 'Duck'
 
   scope :in_shin_pond, where(:pond => 'Shin')
 
+end
+
+class Duckling < Duck
 end
 
 # Negative examples


### PR DESCRIPTION
ranked-model doesn't properly support situations where you wish to rank STI-models as one group of models. As-is, it scopes the ranking to instance.class, which breaks sorting if you for instance have a list of User-models with inherited Admin and Client-models, and you want a global sorting scope for all users.

The attached pull requests implements a :class_name option on the "ranks" class method, as such:
ranks :priority, :class_name => 'User'

I've added some specs as well, everything seems to pass.
