### PR TITLE
Bugfix: Added to_sql on current_last ordering to fix Arel breaking MySQL sy...

### DIFF
--- a/lib/ranked-model/ranker.rb
+++ b/lib/ranked-model/ranker.rb
@@ -233,7 +233,7 @@ module RankedModel
         @current_last ||= begin
           if (ordered_instance = finder.
                                    except( :order ).
-                                   order( instance.class.arel_table[ranker.column].desc ).
+                                   order( instance.class.arel_table[ranker.column].desc.to_sql ).
                                    first)
             RankedModel::Ranker::Mapper.new ranker, ordered_instance
           end


### PR DESCRIPTION
...ntax

Actually I managed to find a work around on this - I assume the ordering without to_sql worked on an older version of Arel or something.

Cheers!
