### PR TITLE
Explain in the readme that position numbers are zero-indexed

### DIFF
--- a/Readme.mkd
+++ b/Readme.mkd
@@ -49,6 +49,9 @@ implement a sorting UI, just update the resource with the position instead:
 @duck.update_attribute :row_order_position, 0  # or 1, 2, 37. :first and :last are also valid
 ```
 
+Position numbers begin at zero.  A position number greater than the number of records acts the
+same as :last.
+
 So using a normal json controller where `@duck.attributes = params[:duck]; @duck.save`, JS can
 look pretty elegant:
 


### PR DESCRIPTION
The example shows the use of a zero, but nowhere does it specifically say that position numbers are zero-indexed.  This cost me no small amount of troubleshooting.  I think it would help others to explain this.
