### PR TITLE
current_last not descending so it returns the first ranked model instead (weird arel problem).

### DIFF
--- a/lib/ranked-model.rb
+++ b/lib/ranked-model.rb
@@ -28,7 +28,9 @@ module RankedModel
 
   def handle_ranking
     self.class.rankers.each do |ranker|
-      ranker.with(self).handle_ranking
+      unless self.send("#{ranker.name}_disable_ranking_hooks")
+        ranker.with(self).handle_ranking
+      end
     end
   end
 
@@ -47,6 +49,7 @@ module RankedModel
       ranker = RankedModel::Ranker.new(*args)
       self.rankers << ranker
       attr_accessor "#{ranker.name}_position"
+      attr_accessor "#{ranker.name}_disable_ranking_hooks"
       public "#{ranker.name}_position", "#{ranker.name}_position="
     end
 


### PR DESCRIPTION
Fixing current_last. It was returning the first instead of the last for some reason in rails 3.2.5. I am also passing a :with_same parameter and had a default scope which put my models in ranked order. Switching to reverse_order simplified the code and fixed the problem.

So in case anyone else stumbles across this issue this is the fix that worked for me.
