### PR TITLE
Add :unless option to Ranker

### DIFF
--- a/lib/ranked-model/ranker.rb
+++ b/lib/ranked-model/ranker.rb
@@ -4,14 +4,14 @@ module RankedModel
   class InvalidField < StandardError; end
 
   class Ranker
-    attr_accessor :name, :column, :scope, :with_same, :class_name
+    attr_accessor :name, :column, :scope, :with_same, :class_name, :unless
 
     def initialize name, options={}
       self.name = name.to_sym
       self.column = options[:column] || name
       self.class_name = options[:class_name]
 
-      [ :scope, :with_same ].each do |key|
+      [ :scope, :with_same, :unless ].each do |key|
         self.send "#{key}=", options[key]
       end
     end
@@ -50,6 +50,13 @@ module RankedModel
       end
 
       def handle_ranking
+        case ranker.unless
+        when Proc
+          return if ranker.unless.call(instance)
+        when Symbol
+          return if instance.send(ranker.unless)
+        end
+
         update_index_from_position
         assure_unique_position
       end

--- a/spec/ranked-model/ranker_spec.rb
+++ b/spec/ranked-model/ranker_spec.rb
@@ -5,10 +5,11 @@ describe RankedModel::Ranker, 'initialized' do
   subject {
     RankedModel::Ranker.new \
       :overview,
-      :column    => :a_sorting_column,
-      :scope     => :a_scope,
-      :with_same => :a_column,
-      :class_name => 'SomeClass'
+      :column     => :a_sorting_column,
+      :scope      => :a_scope,
+      :with_same  => :a_column,
+      :class_name => 'SomeClass',
+      :unless     => :a_method
   }
 
   its(:name) { should == :overview }
@@ -16,4 +17,48 @@ describe RankedModel::Ranker, 'initialized' do
   its(:scope) { should == :a_scope }
   its(:with_same) { should == :a_column }
   its(:class_name) { should == 'SomeClass' }
+  its(:unless) { should == :a_method }
+end
+
+describe RankedModel::Ranker, 'unless as Symbol' do
+  let(:receiver) { mock('model') }
+
+  subject {
+    RankedModel::Ranker.new(:overview, :unless => :a_method).with(receiver)
+  }
+
+  context 'returns true' do
+    before { receiver.expects(:a_method).once.returns(true) }
+
+    its(:handle_ranking) { should == nil }
+  end
+
+  context 'returns false' do
+    before { receiver.expects(:a_method).once.returns(false) }
+
+    it {
+      subject.expects(:update_index_from_position).once
+      subject.expects(:assure_unique_position).once
+
+      subject.handle_ranking
+    }
+  end
+end
+
+describe RankedModel::Ranker, 'unless as Proc' do
+  context 'returns true' do
+    subject { RankedModel::Ranker.new(:overview, :unless => Proc.new { true }).with(Class.new) }
+    its(:handle_ranking) { should == nil }
+  end
+
+  context 'returns false' do
+    subject { RankedModel::Ranker.new(:overview, :unless => Proc.new { false }).with(Class.new) }
+
+    it {
+      subject.expects(:update_index_from_position).once
+      subject.expects(:assure_unique_position).once
+
+      subject.handle_ranking
+    }
+  end
 end


### PR DESCRIPTION
For my particular use case, I'm using ranked-model with a self-referential tree structure. I don't want root nodes to have a position. Thus, I added an unless option that is checked in `Ranker#handle_ranking`.

For example:

```
ranks :position, unless: :root_node?
```
