### PR TITLE
Allow up and down positioning.

### DIFF
--- a/Readme.mkd
+++ b/Readme.mkd
@@ -48,11 +48,11 @@ The ranking integers stored in the `row_order` column will be big and spaced apa
 implement a sorting UI, just update the resource with the position instead:
 
 ``` ruby
-@duck.update_attribute :row_order_position, 0  # or 1, 2, 37. :first and :last are also valid
+@duck.update_attribute :row_order_position, 0  # or 1, 2, 37. :first, :last, :middle, :up and :down are also valid
 ```
 
 Position numbers begin at zero.  A position number greater than the number of records acts the
-same as :last.
+same as `:last`. `:up` and `:down` move the record on step up/down the ladder.
 
 So using a normal json controller where `@duck.attributes = params[:duck]; @duck.save`, JS can
 look pretty elegant:
@@ -78,11 +78,11 @@ class Duck < ActiveRecord::Base
 
   ranks :row_order,           # Name this ranker, used with rank()
     :column => :sort_order    # Override the default column, which defaults to the name
-  
+
   belongs_to :pond
   ranks :swimming_order,
     :with_same => :pond_id    # Ducks belong_to Ponds, make the ranker scoped to one pond
-  
+
   scope :walking, where(:walking => true )
   ranks :walking_order,
     :scope => :walking        # Narrow this ranker to a scope

--- a/lib/ranked-model/ranker.rb
+++ b/lib/ranked-model/ranker.rb
@@ -120,6 +120,12 @@ module RankedModel
             end
           when :middle, 'middle'
             rank_at( ( ( RankedModel::MAX_RANK_VALUE - RankedModel::MIN_RANK_VALUE ).to_f / 2 ).ceil + RankedModel::MIN_RANK_VALUE )
+          when :up, 'up'
+            curr_pos = current_position(rank)
+            position_at (curr_pos > 0 ? curr_pos - 1 : :first)
+          when :down, 'down'
+            curr_pos = current_position(rank)
+            position_at curr_pos + 1
           when String
             position_at position.to_i
           when 0
@@ -236,6 +242,10 @@ module RankedModel
             RankedModel::Ranker::Mapper.new ranker, ordered_instance
           }
         end
+      end
+
+      def current_position _rank
+        finder.take_while { |i| i.send("#{ranker.column}") < _rank }.size
       end
 
       def current_first

--- a/spec/duck-model/duck_spec.rb
+++ b/spec/duck-model/duck_spec.rb
@@ -62,9 +62,9 @@ describe Duck do
     subject { Duck.in_shin_pond.rank(:size).to_a }
 
     its(:size) { should == 3 }
-    
+
     its(:first) { should == @ducks[:quacky] }
-    
+
     its(:last) { should == @ducks[:wingy] }
 
   end
@@ -79,9 +79,9 @@ describe Duck do
     subject { Duck.where(:pond => 'Shin').rank(:age).to_a }
 
     its(:size) { should == 3 }
-    
+
     its(:first) { should == @ducks[:wingy] }
-    
+
     its(:last) { should == @ducks[:quacky] }
 
   end
@@ -98,9 +98,9 @@ describe Duck do
     subject { Duck.rank(:row).to_a }
 
     its(:size) { should == 6 }
-    
+
     its(:first) { should == @ducks[:beaky] }
-    
+
     its(:last) { should == @ducks[:wingy] }
 
   end
@@ -117,26 +117,26 @@ describe Duck do
       @ducks[:webby].update_attribute :row_position, 6
     }
 
-    describe "row" do 
+    describe "row" do
 
       subject { Duck.rank(:row).to_a }
 
       its(:size) { should == 6 }
-      
+
       its(:first) { should == @ducks[:beaky] }
-      
+
       its(:last) { should == @ducks[:webby] }
 
     end
 
-    describe "row" do 
+    describe "row" do
 
       subject { Duck.in_shin_pond.rank(:size).to_a }
 
       its(:size) { should == 3 }
-      
+
       its(:first) { should == @ducks[:quacky] }
-      
+
       its(:last) { should == @ducks[:feathers] }
 
     end
@@ -178,7 +178,7 @@ describe Duck do
         subject { Duck.rank(:row).collect {|duck| duck.id } }
 
         it { subject[0..1].should == @ordered[0..1] }
-        
+
         it { subject[3..subject.length].should == @ordered[2..@ordered.length] }
 
       }
@@ -213,7 +213,7 @@ describe Duck do
         subject { Duck.rank(:row).collect {|duck| duck.id } }
 
         it { subject[1..subject.length].should == @ordered }
-        
+
       }
 
     end
@@ -254,7 +254,7 @@ describe Duck do
         subject { Duck.rank(:row).collect {|duck| duck.id } }
 
         it { subject[0..-2].should == @ordered }
-        
+
       }
 
     end
@@ -295,11 +295,11 @@ describe Duck do
         subject { Duck.rank(:row).collect {|duck| duck.id } }
 
         it { subject[0..-2].should == @ordered }
-        
+
       }
 
     end
-    
+
     describe "at the end with string" do
 
       before {
@@ -336,7 +336,7 @@ describe Duck do
         subject { Duck.rank(:row).collect {|duck| duck.id } }
 
         it { subject[0..-2].should == @ordered }
-        
+
       }
 
     end
@@ -392,9 +392,9 @@ describe Duck do
     subject { Duck.in_lake_and_flock(0,0).rank(:landing_order).to_a }
 
     its(:size) { should == 3 }
-    
+
     its(:first) { should == @ducks[:quacky] }
-    
+
     its(:last) { should == @ducks[:feathers] }
 
   end
@@ -423,3 +423,140 @@ describe Duck do
   end
 
 end
+
+# Up and down positioning
+describe Duck do
+
+  before {
+    @ducks = {
+      :quacky => Duck.create(:name => 'Quacky'),
+      :feathers => Duck.create(:name => 'Feathers'),
+      :wingy => Duck.create(:name => 'Wingy'),
+      :webby => Duck.create(:name => 'Webby'),
+      :waddly => Duck.create(:name => 'Waddly'),
+      :beaky => Duck.create(:name => 'Beaky')
+    }
+    @ducks.each {|name, duck| duck.reload }
+  }
+
+  describe "up positioning" do
+
+    describe "with symbol" do
+      before {
+        @ducks[:wingy].update_attribute :row_position, :up
+      }
+
+      context {
+        subject { Duck.rank(:row)[1] }
+        its(:id) { should == @ducks[:wingy].id }
+      }
+
+      context {
+        subject { Duck.rank(:row)[2] }
+        its(:id) { should == @ducks[:feathers].id }
+      }
+    end
+
+    describe "with string" do
+      before {
+        @ducks[:wingy].update_attribute :row_position, "up"
+      }
+
+      context {
+        subject { Duck.rank(:row)[1] }
+        its(:id) { should == @ducks[:wingy].id }
+      }
+
+      context {
+        subject { Duck.rank(:row)[2] }
+        its(:id) { should == @ducks[:feathers].id }
+      }
+    end
+
+  end
+
+  describe "up positioning of first duck" do
+
+      describe "with symbol" do
+        before {
+          @ducks[:quacky].update_attribute :row_position, :up
+        }
+
+        subject { Duck.rank(:row).first }
+
+        its(:id) { should == @ducks[:quacky].id }
+      end
+
+      describe "with string" do
+        before {
+          @ducks[:quacky].update_attribute :row_position, "up"
+        }
+
+        subject { Duck.rank(:row).first }
+
+        its(:id) { should == @ducks[:quacky].id }
+      end
+
+  end
+
+  describe "down positioning" do
+
+      describe "with symbol" do
+        before {
+          @ducks[:wingy].update_attribute :row_position, :down
+        }
+
+        context {
+          subject { Duck.rank(:row)[3] }
+          its(:id) { should == @ducks[:wingy].id }
+        }
+
+        context {
+          subject { Duck.rank(:row)[2] }
+          its(:id) { should == @ducks[:webby].id }
+        }
+      end
+
+      describe "with string" do
+        before {
+          @ducks[:wingy].update_attribute :row_position, "down"
+        }
+
+        context {
+          subject { Duck.rank(:row)[3] }
+          its(:id) { should == @ducks[:wingy].id }
+        }
+
+        context {
+          subject { Duck.rank(:row)[2] }
+          its(:id) { should == @ducks[:webby].id }
+        }
+      end
+
+  end
+
+  describe "down positioning of last duck" do
+
+      describe "with symbol" do
+        before {
+          @ducks[:beaky].update_attribute :row_position, :down
+        }
+
+        subject { Duck.rank(:row).last }
+
+        its(:id) { should == @ducks[:beaky].id }
+      end
+
+      describe "with string" do
+        before {
+          @ducks[:beaky].update_attribute :row_position, "down"
+        }
+
+        subject { Duck.rank(:row).last }
+
+        its(:id) { should == @ducks[:beaky].id }
+      end
+
+  end
+end
+


### PR DESCRIPTION
Thought it would be nice to just use `:up` and `:down` to move a record up and down:

``` ruby
@duck.update_attribute :row_order_position, :up # or "up"
@duck.update_attribute :row_order_position, :down # or "down"
```
