### PR TITLE
Support aliasing position column

### DIFF
--- a/lib/ranked-model/ranker.rb
+++ b/lib/ranked-model/ranker.rb
@@ -74,7 +74,7 @@ module RankedModel
       end
 
       def rank
-        instance.send "#{ranker.column}"
+        instance[ranker.column]
       end
 
       def current_at_position _pos
@@ -99,7 +99,7 @@ module RankedModel
       end
 
       def rank_at value
-        instance.send "#{ranker.column}=", value
+        instance[ranker.column] = value
       end
 
       def rank_changed?

--- a/spec/actor-model/actor_spec.rb
+++ b/spec/actor-model/actor_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe Player do
+
+  before {
+    @actors = {}
+    @actors[:doctor] = Actor.create!(:name => "David Tennant", position: 1)
+    @actors[:rose] = Actor.create!(:name => "Billie Piper", position: 2)
+    Actor.class_eval do
+      include RankedModel
+      ranks :legacy, :column => :position
+      alias_method :position, :legacy_position
+      alias_method :position=, :legacy_position=
+    end
+  }
+
+  describe "aliasing a legacy acts_as_list position column" do
+    it "updates the position" do
+      @actors[:rose].update_attributes! :position => 1
+      @actors[:rose].reload
+      @actors[:rose].position.should == 1
+    end
+  end
+
+end

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -56,6 +56,11 @@ ActiveRecord::Schema.define :version => 0 do
     t.string :city
     t.integer :score
   end
+
+  create_table :actors, :force => true do |t|
+    t.string :name
+    t.integer :position
+  end
 end
 
 class Duck < ActiveRecord::Base
@@ -138,5 +143,9 @@ class Ego < ActiveRecord::Base
 end
 
 class Player < ActiveRecord::Base
+  # don't add rank yet, do it in the specs
+end
+
+class Actor < ActiveRecord::Base
   # don't add rank yet, do it in the specs
 end


### PR DESCRIPTION
To support migrating projects from acts_as_list, the ranker should access the column value through the model's attributes, and not the accessor method which should be kept free for aliasing.

Ranker works with the internal column values in all other cases, I believe it should do so with the `rank` and `rank_at` methods too. This frees up the accessor method for aliasing to represent the external position value.

The added spec shows how this small change could be useful for existing models that use "position" as the column name and accessor method.
