### PR TITLE
rebalance ranks when we try to position an item between two other items with identical ranks.

### DIFF
--- a/lib/ranked-model/ranker.rb
+++ b/lib/ranked-model/ranker.rb
@@ -148,7 +148,12 @@ module RankedModel
             neighbors = neighbors_at_position(position)
             min = ((neighbors[:lower] && neighbors[:lower].has_rank?) ? neighbors[:lower].rank : RankedModel::MIN_RANK_VALUE)
             max = ((neighbors[:upper] && neighbors[:upper].has_rank?) ? neighbors[:upper].rank : RankedModel::MAX_RANK_VALUE)
-            rank_at( ( ( max - min ).to_f / 2 ).ceil + min )
+            if min == max
+              rebalance_ranks
+              position_at position
+            else
+              rank_at( ( ( max - min ).to_f / 2 ).ceil + min )
+            end
           when NilClass
             if !rank
               position_at :last


### PR DESCRIPTION
This handles the edge case of trying to position an item between two items that have the same rank as each other.  This, obviously, shouldn't happen, but easily can.  

For example, it is possible (actually, likely) in a production scenario when many items (that are part of a ranking) are created at the same time, across multiple server processes/threads.  You'll end up with items with the same ranking.  

This fix doesn't stop that from happening, but it ensures that there is eventually consistent data when the items get re-ranked.  

Without this, if you try to rank an item between two items with the same rank, nobody's ranking is changed (neither the item you're trying to rank, nor the neighbors).
