### PR TITLE
Allow using Proc for :with_same option

### DIFF
--- a/Readme.mkd
+++ b/Readme.mkd
@@ -82,14 +82,21 @@ class Duck < ActiveRecord::Base
 
   ranks :row_order,           # Name this ranker, used with rank()
     :column => :sort_order    # Override the default column, which defaults to the name
-  
+
   belongs_to :pond
   ranks :swimming_order,
     :with_same => :pond_id    # Ducks belong_to Ponds, make the ranker scoped to one pond
-  
+
   scope :walking, where(:walking => true )
   ranks :walking_order,
     :scope => :walking        # Narrow this ranker to a scope
+
+  # Imagine ducks optionally belong_to Flocks as well. When they're associated with a Flock
+  # make the ranker scoped to one flock, otherwise scope to one pond.
+
+  belongs_to :flock
+  ranks :pecking_order,
+    :with_same => Proc.new { |duck| duck.flock_id ? :flock_id : :pond_id }
 
 end
 ```

--- a/lib/ranked-model/ranker.rb
+++ b/lib/ranked-model/ranker.rb
@@ -221,17 +221,19 @@ module RankedModel
           if ranker.scope
             _finder = _finder.send ranker.scope
           end
-          case ranker.with_same
+
+          with_same = ranker.with_same.respond_to?(:call) ? ranker.with_same.call(instance) : ranker.with_same
+          case with_same
             when Symbol
-              columns << instance_class.arel_table[ranker.with_same]
+              columns << instance_class.arel_table[with_same]
               _finder = _finder.where \
-                instance_class.arel_table[ranker.with_same].eq(instance.attributes["#{ranker.with_same}"])
+                instance_class.arel_table[with_same].eq(instance.attributes["#{with_same}"])
             when Array
-              ranker.with_same.each {|c| columns.push instance_class.arel_table[c] }
+              with_same.each {|c| columns.push instance_class.arel_table[c] }
               _finder = _finder.where(
-                ranker.with_same[1..-1].inject(
-                  instance_class.arel_table[ranker.with_same.first].eq(
-                    instance.attributes["#{ranker.with_same.first}"]
+                with_same[1..-1].inject(
+                  instance_class.arel_table[with_same.first].eq(
+                    instance.attributes["#{with_same.first}"]
                   )
                 ) {|scoper, attr|
                   scoper.and(

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -18,6 +18,7 @@ ActiveRecord::Schema.define :version => 0 do
     t.integer :lake_id
     t.integer :flock_id
     t.integer :landing_order
+    t.integer :pecking_order
     t.string :pond
   end
 
@@ -64,9 +65,13 @@ class Duck < ActiveRecord::Base
   ranks :row
   ranks :size, :scope => :in_shin_pond
   ranks :age, :with_same => :pond
+  ranks :pecking_order, :with_same => Proc.new { |d| d.lake_id ? :lake_id : :flock_id }
 
   ranks :landing_order, :with_same => [:lake_id, :flock_id]
   scope :in_lake_and_flock, lambda {|lake, flock| where(:lake_id => lake, :flock_id => flock) }
+
+  scope :in_lake, lambda { |lake| where(:lake_id => lake) }
+  scope :without_lake, lambda { where(:lake_id => nil) }
 
   scope :in_shin_pond, lambda { where(:pond => 'Shin') }
 


### PR DESCRIPTION
I ran into a case where I needed choose the :with_same field based on
a state of an instance. The specific example was a model that belongs
a user but may also belong to a team. When it belongs to a team, it
should be ordered by the team_id, otherwise it should be ordered by
the user_id.

This commit allows handling this case in a pretty straightforward
manner. By using a Proc that takes the instance as a block argument,
we can dynamically choose the :with_same field based on the state of
the instance at rank-time.
