### PR TITLE
clarify missing field error message when using an Array for the with_same option

### DIFF
--- a/lib/ranked-model/ranker.rb
+++ b/lib/ranked-model/ranker.rb
@@ -40,11 +40,11 @@ module RankedModel
                 when Symbol
                   !instance.respond_to?(ranker.with_same)
                 when Array
-                  ranker.with_same.detect {|attr| !instance.respond_to?(attr) }
+                  array_element = ranker.with_same.detect {|attr| !instance.respond_to?(attr) }
                 else
                   false
               end)
-            raise RankedModel::InvalidField, %Q{No field called "#{ranker.with_same}" found in model}
+            raise RankedModel::InvalidField, %Q{No field called "#{array_element || ranker.with_same}" found in model}
           end
         end
       end

--- a/spec/duck-model/wrong_ducks_spec.rb
+++ b/spec/duck-model/wrong_ducks_spec.rb
@@ -23,3 +23,14 @@ describe WrongFieldDuck do
   end
 
 end
+
+describe ReallyWrongFieldDuck do
+
+  it "should raise an error because of a specific unknown field" do
+
+    expect {
+      ReallyWrongFieldDuck.create(:name => 'Quicky', :pond => 'Shin')
+    }.to raise_error(RankedModel::InvalidField, 'No field called "non_existant_field" found in model')
+  end
+
+end

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -85,7 +85,12 @@ class WrongFieldDuck < ActiveRecord::Base
 
   include RankedModel
   ranks :age, :with_same => :non_existant_field
+end
 
+class ReallyWrongFieldDuck < ActiveRecord::Base
+  self.table_name = :wrong_field_ducks
+  include RankedModel
+  ranks :age, :with_same => [:name, :non_existant_field]
 end
 
 # Example for STI, ranking within each child class


### PR DESCRIPTION
This PR clarifies the error message you receive when supplying an Array of fields to the `with_same`: 

``` ruby
ranks :row_order, with_same: [:name, :non_existant_field]
```

which currently returns this message:

```
No field called "[:name, :non_existant_field]" found in model
```

But now you receive a precise error detailing which field is problematic:

```
No field called "non_existant_field" found in model
```
