### PR TITLE
Add collision policy

### DIFF
--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -56,6 +56,11 @@ ActiveRecord::Schema.define :version => 0 do
     t.string :city
     t.integer :score
   end
+
+  create_table :tasks, :force => true do |t|
+    t.string :name
+    t.integer :row_order
+  end
 end
 
 class Duck < ActiveRecord::Base
@@ -144,4 +149,17 @@ end
 
 class Player < ActiveRecord::Base
   # don't add rank yet, do it in the specs
+end
+
+class Task < ActiveRecord::Base
+  # don't add rank yet, do it in the specs
+
+  def self.create_tasks_in_same_position(position, number_of_tasks = 1)
+    tasks = []
+    number_of_tasks.times do |n|
+      tasks << create(name: "task name #{n}", row_order_position: position)
+    end
+    tasks
+  end
+
 end

--- a/spec/task_model/task_spec.rb
+++ b/spec/task_model/task_spec.rb
@@ -59,7 +59,7 @@ describe Task do
       end
     end
 
-    it 'use rearrange collision policy using shift' do
+    it 'use rebalance collision policy and not use shift' do
       expect(tasks[-1].row_order).to_not eq(-8388606)
       expect(tasks[-2].row_order).to_not eq(tasks[-1].row_order + 1)
       expect(tasks[-3].row_order).to_not eq(tasks[-2].row_order + 1)

--- a/spec/task_model/task_spec.rb
+++ b/spec/task_model/task_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+
+describe Task do
+  let(:tasks) do
+    tasks = Task.create_tasks_in_same_position(0, 25)
+    Task.find(tasks.map(&:id))
+  end
+
+  context 'without collision_policy' do
+    before do
+      Task.class_eval do
+        include RankedModel
+        ranks :row_order
+      end
+    end
+
+    it 'use rearrange default collision policy using shift' do
+      expect(tasks[-1].row_order).to eq(-8388606)
+      expect(tasks[-2].row_order).to eq(tasks[-1].row_order + 1)
+      expect(tasks[-3].row_order).to eq(tasks[-2].row_order + 1)
+    end
+  end
+
+  context 'bad collision_policy' do
+    before do
+      Task.class_eval do
+        include RankedModel
+        ranks :row_order, collision_policy: :bad
+      end
+    end
+
+    it 'use rearrange default collision policy using shift' do
+      expect(tasks[-1].row_order).to eq(-8388606)
+      expect(tasks[-2].row_order).to eq(tasks[-1].row_order + 1)
+      expect(tasks[-3].row_order).to eq(tasks[-2].row_order + 1)
+    end
+  end
+
+  context 'rearrange collision_policy' do
+    before do
+      Task.class_eval do
+        include RankedModel
+        ranks :row_order, collision_policy: :rearrange
+      end
+    end
+
+    it 'use rearrange collision policy using shift' do
+      expect(tasks[-1].row_order).to eq(-8388606)
+      expect(tasks[-2].row_order).to eq(tasks[-1].row_order + 1)
+      expect(tasks[-3].row_order).to eq(tasks[-2].row_order + 1)
+    end
+  end
+
+  context 'rebalance collision_policy' do
+    before do
+      Task.class_eval do
+        include RankedModel
+        ranks :row_order, collision_policy: :rebalance
+      end
+    end
+
+    it 'use rearrange collision policy using shift' do
+      expect(tasks[-1].row_order).to_not eq(-8388606)
+      expect(tasks[-2].row_order).to_not eq(tasks[-1].row_order + 1)
+      expect(tasks[-3].row_order).to_not eq(tasks[-2].row_order + 1)
+    end
+  end
+
+end


### PR DESCRIPTION
When ranked models are set in the same first or last position, the 24th
element will have the RankedModel::MIN_RANK_VALUE or RankedModel::MAX_RANK_VALUE.

Apply rearrange will force to shift for the all the next elements in the first/last position, when the list is really large performs an sql like:

```
UPDATE `table` SET position_column = position_column + 1 where
`table`.`position_column` >= -8388606
```

and its lock rows that can cause performance issues.

Setting the `collision_policy: :rebalance` for ranked models that usually inserts in the same first/last position will reduce the performance issues in very large ranked lists.
