### PR TITLE
Conditionally extend MAX_RANKs to 4-byte integer range for PostgreSQL

### DIFF
--- a/lib/ranked-model/ranker.rb
+++ b/lib/ranked-model/ranker.rb
@@ -114,30 +114,30 @@ module RankedModel
         case position
           when :first, 'first'
             if current_first && current_first.rank
-              rank_at( ( ( RankedModel::MIN_RANK_VALUE - current_first.rank ).to_f / 2 ).ceil + current_first.rank)
+              rank_at( ( ( RankedModel::MIN_RANK_VALUE.call - current_first.rank ).to_f / 2 ).ceil + current_first.rank)
             else
               position_at :middle
             end
           when :last, 'last'
             if current_last && current_last.rank
-              rank_at( ( ( RankedModel::MAX_RANK_VALUE - current_last.rank ).to_f / 2 ).ceil + current_last.rank )
+              rank_at( ( ( RankedModel::MAX_RANK_VALUE.call - current_last.rank ).to_f / 2 ).ceil + current_last.rank )
             else
               position_at :middle
             end
           when :middle, 'middle'
-            rank_at( ( ( RankedModel::MAX_RANK_VALUE - RankedModel::MIN_RANK_VALUE ).to_f / 2 ).ceil + RankedModel::MIN_RANK_VALUE )
+            rank_at( ( ( RankedModel::MAX_RANK_VALUE.call - RankedModel::MIN_RANK_VALUE.call ).to_f / 2 ).ceil + RankedModel::MIN_RANK_VALUE.call )
           when :down, 'down'
             neighbors = find_next_two(rank)
             if neighbors[:lower]
               min = neighbors[:lower].rank
-              max = neighbors[:upper] ? neighbors[:upper].rank : RankedModel::MAX_RANK_VALUE
+              max = neighbors[:upper] ? neighbors[:upper].rank : RankedModel::MAX_RANK_VALUE.call
               rank_at( ( ( max - min ).to_f / 2 ).ceil + min )
             end
           when :up, 'up'
             neighbors = find_previous_two(rank)
             if neighbors[:upper]
               max = neighbors[:upper].rank
-              min = neighbors[:lower] ? neighbors[:lower].rank : RankedModel::MIN_RANK_VALUE
+              min = neighbors[:lower] ? neighbors[:lower].rank : RankedModel::MIN_RANK_VALUE.call
               rank_at( ( ( max - min ).to_f / 2 ).ceil + min )
             end
           when String
@@ -146,8 +146,8 @@ module RankedModel
             position_at :first
           when Integer
             neighbors = neighbors_at_position(position)
-            min = ((neighbors[:lower] && neighbors[:lower].has_rank?) ? neighbors[:lower].rank : RankedModel::MIN_RANK_VALUE)
-            max = ((neighbors[:upper] && neighbors[:upper].has_rank?) ? neighbors[:upper].rank : RankedModel::MAX_RANK_VALUE)
+            min = ((neighbors[:lower] && neighbors[:lower].has_rank?) ? neighbors[:lower].rank : RankedModel::MIN_RANK_VALUE.call)
+            max = ((neighbors[:upper] && neighbors[:upper].has_rank?) ? neighbors[:upper].rank : RankedModel::MAX_RANK_VALUE.call)
             rank_at( ( ( max - min ).to_f / 2 ).ceil + min )
           when NilClass
             if !rank
@@ -159,10 +159,10 @@ module RankedModel
       def assure_unique_position
         if ( new_record? || rank_changed? )
           unless rank
-            rank_at( RankedModel::MAX_RANK_VALUE )
+            rank_at( RankedModel::MAX_RANK_VALUE.call )
           end
 
-          if (rank > RankedModel::MAX_RANK_VALUE) || current_at_rank(rank)
+          if (rank > RankedModel::MAX_RANK_VALUE.call) || current_at_rank(rank)
             rearrange_ranks
           end
         end
@@ -174,15 +174,15 @@ module RankedModel
           # Never update ourself, shift others around us.
           _scope = _scope.where( instance_class.arel_table[instance_class.primary_key].not_eq(instance.id) )
         end
-        if current_first.rank && current_first.rank > RankedModel::MIN_RANK_VALUE && rank == RankedModel::MAX_RANK_VALUE
+        if current_first.rank && current_first.rank > RankedModel::MIN_RANK_VALUE.call && rank == RankedModel::MAX_RANK_VALUE.call
           _scope.
             where( instance_class.arel_table[ranker.column].lteq(rank) ).
             update_all( %Q{#{ranker.column} = #{ranker.column} - 1} )
-        elsif current_last.rank && current_last.rank < (RankedModel::MAX_RANK_VALUE - 1) && rank < current_last.rank
+        elsif current_last.rank && current_last.rank < (RankedModel::MAX_RANK_VALUE.call - 1) && rank < current_last.rank
           _scope.
             where( instance_class.arel_table[ranker.column].gteq(rank) ).
             update_all( %Q{#{ranker.column} = #{ranker.column} + 1} )
-        elsif current_first.rank && current_first.rank > RankedModel::MIN_RANK_VALUE && rank > current_first.rank
+        elsif current_first.rank && current_first.rank > RankedModel::MIN_RANK_VALUE.call && rank > current_first.rank
           _scope.
             where( instance_class.arel_table[ranker.column].lt(rank) ).
             update_all( %Q{#{ranker.column} = #{ranker.column} - 1} )
@@ -197,7 +197,7 @@ module RankedModel
         has_set_self = false
         total.times do |index|
           next if index == 0 || index == total
-          rank_value = ((((RankedModel::MAX_RANK_VALUE - RankedModel::MIN_RANK_VALUE).to_f / total) * index ).ceil + RankedModel::MIN_RANK_VALUE)
+          rank_value = ((((RankedModel::MAX_RANK_VALUE.call - RankedModel::MIN_RANK_VALUE.call).to_f / total) * index ).ceil + RankedModel::MIN_RANK_VALUE.call)
           index = index - 1
           if has_set_self
             index = index - 1

--- a/spec/duck-model/lots_of_ducks_spec.rb
+++ b/spec/duck-model/lots_of_ducks_spec.rb
@@ -73,8 +73,8 @@ describe Duck do
         @first = Duck.first
         @second = Duck.offset(1).first
         @ordered = Duck.rank(:row).where(Duck.arel_table[:id].not_in([@first.id, @second.id])).collect {|d| d.id }
-        @first.update_attribute :row, RankedModel::MAX_RANK_VALUE
-        @second.update_attribute :row, RankedModel::MAX_RANK_VALUE
+        @first.update_attribute :row, RankedModel::MAX_RANK_VALUE.call
+        @second.update_attribute :row, RankedModel::MAX_RANK_VALUE.call
       }
 
       context {
@@ -96,8 +96,8 @@ describe Duck do
         @duck_11 = Duck.offset(10).first
         @duck_12 = Duck.offset(11).first
         @ordered = Duck.where(:pond => 'Pond 1').rank(:age).where(Duck.arel_table[:id].not_in([@duck_11.id, @duck_12.id])).collect {|d| d.id }
-        @duck_11.update_attribute :age, RankedModel::MAX_RANK_VALUE
-        @duck_12.update_attribute :age, RankedModel::MAX_RANK_VALUE
+        @duck_11.update_attribute :age, RankedModel::MAX_RANK_VALUE.call
+        @duck_12.update_attribute :age, RankedModel::MAX_RANK_VALUE.call
       }
 
       context {
@@ -119,8 +119,8 @@ describe Duck do
         @first = Duck.first
         @second = Duck.offset(1).first
         @ordered = Duck.rank(:row).where(Duck.arel_table[:id].not_in([@first.id, @second.id])).collect {|d| d.id }
-        @first.update_attribute :row, RankedModel::MIN_RANK_VALUE
-        @second.update_attribute :row, RankedModel::MIN_RANK_VALUE
+        @first.update_attribute :row, RankedModel::MIN_RANK_VALUE.call
+        @second.update_attribute :row, RankedModel::MIN_RANK_VALUE.call
       }
 
       context {
@@ -137,20 +137,20 @@ describe Duck do
 
       before {
         @first = Duck.first
-        @second = Duck.where(:row => RankedModel::MAX_RANK_VALUE).first || Duck.offset(1).first
+        @second = Duck.where(:row => RankedModel::MAX_RANK_VALUE.call).first || Duck.offset(1).first
         @third = Duck.offset(2).first
         @fourth = Duck.offset(4).first
         @lower = Duck.rank(:row).
           where(Duck.arel_table[:id].not_in([@first.id, @second.id, @third.id, @fourth.id])).
-          where(Duck.arel_table[:row].lt(RankedModel::MAX_RANK_VALUE / 2)).
+          where(Duck.arel_table[:row].lt(RankedModel::MAX_RANK_VALUE.call / 2)).
           collect {|d| d.id }
         @upper = Duck.rank(:row).
           where(Duck.arel_table[:id].not_in([@first.id, @second.id, @third.id, @fourth.id])).
-          where(Duck.arel_table[:row].gteq(RankedModel::MAX_RANK_VALUE / 2)).
+          where(Duck.arel_table[:row].gteq(RankedModel::MAX_RANK_VALUE.call / 2)).
           collect {|d| d.id }
-        @first.update_attribute :row, RankedModel::MIN_RANK_VALUE
-        @second.update_attribute :row, RankedModel::MAX_RANK_VALUE
-        @third.update_attribute :row, (RankedModel::MAX_RANK_VALUE / 2)
+        @first.update_attribute :row, RankedModel::MIN_RANK_VALUE.call
+        @second.update_attribute :row, RankedModel::MAX_RANK_VALUE.call
+        @third.update_attribute :row, (RankedModel::MAX_RANK_VALUE.call / 2)
         @fourth.update_attribute :row, @third.row
       }
 

--- a/spec/ranked-model/ranked_model_spec.rb
+++ b/spec/ranked-model/ranked_model_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+describe RankedModel, '::MAX_RANK_VALUE' do
+  it 'should be defined' do
+    subject.should be_const_defined(:MAX_RANK_VALUE)
+  end
+
+  it 'should be a proc object' do
+    RankedModel::MAX_RANK_VALUE.should be_a(Proc)
+  end
+
+  context "using postgresql adapter" do
+    before { ActiveRecord::Base.connection.stubs(:adapter_name).returns('postgresql') }
+
+    it "should return 4-byte integer maximum" do
+      RankedModel::MAX_RANK_VALUE.call.should == 2147483647
+    end
+
+  end
+
+  %w(mysql sqlite3).each do |adapter|
+    context "using #{adapter} adapter" do
+      before { ActiveRecord::Base.connection.stubs(:adapter_name).returns(adapter) }
+
+      it "should return 3-byte integer maximum" do
+        RankedModel::MAX_RANK_VALUE.call.should == 8388607
+      end
+    end
+  end
+end
+
+describe RankedModel, '::MIN_RANK_VALUE' do
+  it 'should be defined' do
+    subject.should be_const_defined(:MIN_RANK_VALUE)
+  end
+
+  it 'should be a proc object' do
+    RankedModel::MIN_RANK_VALUE.should be_a(Proc)
+  end
+
+  context "using postgresql adapter" do
+    before { ActiveRecord::Base.connection.stubs(:adapter_name).returns('postgresql') }
+
+    it "should return 4-byte integer MINimum" do
+      RankedModel::MIN_RANK_VALUE.call.should == -2147483648
+    end
+
+  end
+
+  %w(mysql sqlite3).each do |adapter|
+    context "using #{adapter} adapter" do
+      before { ActiveRecord::Base.connection.stubs(:adapter_name).returns(adapter) }
+
+      it "should return 3-byte integer MINimum" do
+        RankedModel::MIN_RANK_VALUE.call.should == -8388607
+      end
+    end
+  end
+end


### PR DESCRIPTION
`MAX_RANK_VALUE` and `MIN_RANK_VALUE` are set to MySQL's 3-byte MEDIUMINT range by default. However, as PostgreSQL doesn't have a 3-byte integer data type and Postgres users are forced into allocating a 4-byte integer anyway, we may as well use the full 4-byte range to reduce the chance of potentially expensive rebalancing.

For reference:
Signed 4-byte INTEGER in PostgreSQL: -2147483648 to +2147483647
Signed 3-byte MEDIUMINT in MySQL: -8388607 to +8388607
SQLite3 allocates space according to size of each value, so we'll stick with the defaults.