### PR TITLE
Extend rank range to 4-byte integers

### DIFF
--- a/Readme.mkd
+++ b/Readme.mkd
@@ -163,7 +163,7 @@ Internals
 
 This library is written using ARel from the ground-up.  This leaves the code much cleaner
 than many implementations.  ranked-model is also optimized to write to the database as little
-as possible: ranks are stored as a number between -8388607 and 8388607 (the MEDIUMINT range in MySQL).
+as possible: ranks are stored as a number between -2147483648 and 2147483647 (the INT range in MySQL).
 When an item is given a new position, it assigns itself a rank number between two neighbors.
 This allows several movements of items before no digits are available between two neighbors. When
 this occurs, ranked-model will try to shift other records out of the way. If items can't be easily

--- a/lib/ranked-model.rb
+++ b/lib/ranked-model.rb
@@ -3,10 +3,10 @@ require File.dirname(__FILE__)+'/ranked-model/railtie' if defined?(Rails::Railti
 
 module RankedModel
 
-  # Signed MEDIUMINT in MySQL
+  # Signed INT in MySQL
   #
-  MAX_RANK_VALUE = 8388607
-  MIN_RANK_VALUE = -8388607
+  MAX_RANK_VALUE = 2147483647
+  MIN_RANK_VALUE = -2147483648
 
   def self.included base
 


### PR DESCRIPTION
As an alternative to https://github.com/mixonic/ranked-model/pull/108, simply hardcode the 4-byte integer range which is supported across MySQL, PostgreSQL and SQLite3 adapters.

As mentioned in #108, 3-byte integer fields are not supported in PostgreSQL, forcing users to allocate 4-bytes so we may as well use the wider range of values this supports to reduce the chance of potentially expensive rebalancing.