### PR TITLE
Fix #90: escape column name in Ranker#rearrange_ranks

### DIFF
--- a/lib/ranked-model/ranker.rb
+++ b/lib/ranked-model/ranker.rb
@@ -179,24 +179,25 @@ module RankedModel
 
       def rearrange_ranks
         _scope = finder
+        escaped_column = ActiveRecord::Base.connection.quote_column_name ranker.column
         # If there is room at the bottom of the list and we're added to the very top of the list...
         if current_first.rank && current_first.rank > RankedModel::MIN_RANK_VALUE && rank == RankedModel::MAX_RANK_VALUE
           # ...then move everyone else down 1 to make room for us at the end
           _scope.
             where( instance_class.arel_table[ranker.column].lteq(rank) ).
-            update_all( "#{ranker.column} = #{ranker.column} - 1" )
+            update_all( "#{escaped_column} = #{escaped_column} - 1" )
         # If there is room at the top of the list and we're added below the last value in the list...
         elsif current_last.rank && current_last.rank < (RankedModel::MAX_RANK_VALUE - 1) && rank < current_last.rank
           # ...then move everyone else at or above our desired rank up 1 to make room for us
           _scope.
             where( instance_class.arel_table[ranker.column].gteq(rank) ).
-            update_all( "#{ranker.column} = #{ranker.column} + 1" )
+            update_all( "#{escaped_column} = #{escaped_column} + 1" )
         # If there is room at the bottom of the list and we're added above the lowest value in the list...
         elsif current_first.rank && current_first.rank > RankedModel::MIN_RANK_VALUE && rank > current_first.rank
           # ...then move everyone else below us down 1 and change our rank down 1 to avoid the collission
           _scope.
             where( instance_class.arel_table[ranker.column].lt(rank) ).
-            update_all( "#{ranker.column} = #{ranker.column} - 1" )
+            update_all( "#{escaped_column} = #{escaped_column} - 1" )
           rank_at( rank - 1 )
         else
           rebalance_ranks

--- a/spec/number-model/number_spec.rb
+++ b/spec/number-model/number_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe Number do
+
+  before {
+    200.times do |i|
+      Number.create :value => i
+    end
+  }
+
+  describe "a rearrangement with keyword column name" do
+
+    before {
+      @first = Number.first
+      @second = Number.offset(1).first
+      @ordered = Number.rank(:order).where(Number.arel_table[:id].not_in([@first.id, @second.id])).collect {|d| d.id }
+      @first.update_attribute :order, RankedModel::MAX_RANK_VALUE
+      @second.update_attribute :order, RankedModel::MAX_RANK_VALUE
+    }
+
+    context {
+
+      subject { Number.rank(:order).collect {|d| d.id } }
+
+      it { should == (@ordered[0..-2] + [@ordered[-1], @first.id, @second.id]) }
+
+    }
+
+  end
+
+end

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -56,6 +56,11 @@ ActiveRecord::Schema.define :version => 0 do
     t.string :city
     t.integer :score
   end
+
+  create_table :numbers, :force => true do |t|
+    t.float :value
+    t.integer :order
+  end
 end
 
 class Duck < ActiveRecord::Base
@@ -144,4 +149,9 @@ end
 
 class Player < ActiveRecord::Base
   # don't add rank yet, do it in the specs
+end
+
+class Number < ActiveRecord::Base
+  include RankedModel
+  ranks :order
 end


### PR DESCRIPTION
This PR fixes #90. Now usage of keyword column name does not produce SQL syntax error anymore in `Ranker#rearrange_ranks` method.

Summary:
- fix `Ranker#rearrange_ranks` SQL syntax error when column name is SQL keyword;
- implement special test case which reproduces #90;
- QA this change for MySQL, PostgreSQL and SQLite.