### PR TITLE
Remove RubySL from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,3 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in ranked-model.gemspec
 gemspec
-
-gem 'rubysl', '~> 2.0', platform: :rbx
-gem 'rubinius-developer_tools', platform: :rbx


### PR DESCRIPTION
These are not needed on supported versions of Rubinius.