### PR TITLE
Fix issue with consecutive final two ranks and setting rank to second to last

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ env:
   - DB=mysql
   - DB=postgresql
 gemfile:
-  - gemfiles/rails_3_2.gemfile
   - gemfiles/rails_4_1.gemfile
   - gemfiles/rails_4_2.gemfile
   - gemfiles/rails_5_0.gemfile
@@ -43,12 +42,6 @@ matrix:
     - rvm: jruby-9.1.17.0
       gemfile: gemfiles/rails_5_2.gemfile
     - rvm: 2.4.4
-      gemfile: gemfiles/rails_3_2.gemfile
-    - rvm: 2.4.4
       gemfile: gemfiles/rails_4_1.gemfile
     - rvm: 2.5.1
-      gemfile: gemfiles/rails_3_2.gemfile
-    - rvm: 2.5.1
       gemfile: gemfiles/rails_4_1.gemfile
-    - env: DB=postgresql
-      gemfile: gemfiles/rails_3_2.gemfile

--- a/Appraisals
+++ b/Appraisals
@@ -1,20 +1,3 @@
-appraise "rails-3-2" do
-  group :sqlite do
-    gem "sqlite3", platform: :ruby
-    gem "activerecord-jdbcsqlite3-adapter", "~> 1.3.24", platform: :jruby
-  end
-  group :mysql do
-    gem "mysql2", "~> 0.3.21", platform: :ruby
-    gem "activerecord-jdbcmysql-adapter", "~> 1.3.24", platform: :jruby
-  end
-  group :postgresql do
-    gem "pg", "~> 0.18.0", platform: :ruby
-    gem "activerecord-jdbcpostgresql-adapter", "~> 1.3.24", platform: :jruby
-  end
-
-  gem "activerecord", "~> 3.2.22.5"
-end
-
 appraise "rails-4-1" do
   group :sqlite do
     gem "sqlite3", platform: :ruby

--- a/Readme.mkd
+++ b/Readme.mkd
@@ -5,7 +5,7 @@
 Installation
 ------------
 
-ranked-model passes specs with Rails 3.2, 4.1, 4.2, 5.0, 5.1 and 5.2 for MySQL, Postgres, and SQLite on Ruby 1.9.3, 2.1 through 2.5, jruby-9.1.17.0, and rbx-3.107 where Rails supports the platform. This is with the exception of Postgres before Rails 4.0 on all platforms, which is unsupported by `ranked-model`. Note that the `pg` gem has pulled support for rbx (Rubinius) from version 1 onward.
+ranked-model passes specs with Rails 4.1, 4.2, 5.0, 5.1 and 5.2 for MySQL, Postgres, and SQLite on Ruby 1.9.3, 2.1 through 2.5, jruby-9.1.17.0, and rbx-3.107 where Rails supports the platform. This is with the exception of Postgres before Rails 4.0 on all platforms, which is unsupported by `ranked-model`. Note that the `pg` gem has pulled support for rbx (Rubinius) from version 1 onward.
 
 TL;DR, if you are using Rails 4 and up you are 100% good to go. Before Rails 4, be wary of Postgres.
 

--- a/lib/ranked-model.rb
+++ b/lib/ranked-model.rb
@@ -40,7 +40,7 @@ module RankedModel
       end
     end
 
-  private
+    private
 
     def ranks *args
       self.rankers ||= []

--- a/lib/ranked-model/ranker.rb
+++ b/lib/ranked-model/ranker.rb
@@ -114,31 +114,31 @@ module RankedModel
         case position
           when :first, 'first'
             if current_first && current_first.rank
-              rank_at( ( ( RankedModel::MIN_RANK_VALUE - current_first.rank ).to_f / 2 ).ceil + current_first.rank)
+              rank_at_average current_first.rank, RankedModel::MIN_RANK_VALUE
             else
               position_at :middle
             end
           when :last, 'last'
             if current_last && current_last.rank
-              rank_at( ( ( RankedModel::MAX_RANK_VALUE - current_last.rank ).to_f / 2 ).ceil + current_last.rank )
+              rank_at_average current_last.rank, RankedModel::MAX_RANK_VALUE
             else
               position_at :middle
             end
           when :middle, 'middle'
-            rank_at( ( ( RankedModel::MAX_RANK_VALUE - RankedModel::MIN_RANK_VALUE ).to_f / 2 ).ceil + RankedModel::MIN_RANK_VALUE )
+            rank_at_average RankedModel::MIN_RANK_VALUE, RankedModel::MAX_RANK_VALUE
           when :down, 'down'
             neighbors = find_next_two(rank)
             if neighbors[:lower]
               min = neighbors[:lower].rank
               max = neighbors[:upper] ? neighbors[:upper].rank : RankedModel::MAX_RANK_VALUE
-              rank_at( ( ( max - min ).to_f / 2 ).ceil + min )
+              rank_at_average min, max
             end
           when :up, 'up'
             neighbors = find_previous_two(rank)
             if neighbors[:upper]
               max = neighbors[:upper].rank
               min = neighbors[:lower] ? neighbors[:lower].rank : RankedModel::MIN_RANK_VALUE
-              rank_at( ( ( max - min ).to_f / 2 ).ceil + min )
+              rank_at_average min, max
             end
           when String
             position_at position.to_i
@@ -148,11 +148,20 @@ module RankedModel
             neighbors = neighbors_at_position(position)
             min = ((neighbors[:lower] && neighbors[:lower].has_rank?) ? neighbors[:lower].rank : RankedModel::MIN_RANK_VALUE)
             max = ((neighbors[:upper] && neighbors[:upper].has_rank?) ? neighbors[:upper].rank : RankedModel::MAX_RANK_VALUE)
-            rank_at( ( ( max - min ).to_f / 2 ).ceil + min )
+            rank_at_average min, max
           when NilClass
             if !rank
               position_at :last
             end
+        end
+      end
+
+      def rank_at_average(min, max)
+        if (max - min).between?(-1, 1) # No room at the inn...
+          rebalance_ranks
+          position_at position
+        else
+          rank_at( ( ( max - min ).to_f / 2 ).ceil + min )
         end
       end
 

--- a/lib/ranked-model/ranker.rb
+++ b/lib/ranked-model/ranker.rb
@@ -167,10 +167,6 @@ module RankedModel
 
       def assure_unique_position
         if ( new_record? || rank_changed? )
-          unless rank
-            rank_at( RankedModel::MAX_RANK_VALUE )
-          end
-
           if (rank > RankedModel::MAX_RANK_VALUE) || current_at_rank(rank)
             rearrange_ranks
           end

--- a/lib/ranked-model/ranker.rb
+++ b/lib/ranked-model/ranker.rb
@@ -66,7 +66,7 @@ module RankedModel
         #
         instance_class.
           where(instance_class.primary_key => instance.id).
-          update_all([%Q{#{ranker.column} = ?}, value])
+          update_all(ranker.column => value)
       end
 
       def position
@@ -188,19 +188,19 @@ module RankedModel
           # ...then move everyone else down 1 to make room for us at the end
           _scope.
             where( instance_class.arel_table[ranker.column].lteq(rank) ).
-            update_all( %Q{#{ranker.column} = #{ranker.column} - 1} )
+            update_all( "#{ranker.column} = #{ranker.column} - 1" )
         # If there is room at the top of the list and we're added below the last value in the list...
         elsif current_last.rank && current_last.rank < (RankedModel::MAX_RANK_VALUE - 1) && rank < current_last.rank
           # ...then move everyone else at or above our desired rank up 1 to make room for us
           _scope.
             where( instance_class.arel_table[ranker.column].gteq(rank) ).
-            update_all( %Q{#{ranker.column} = #{ranker.column} + 1} )
+            update_all( "#{ranker.column} = #{ranker.column} + 1" )
         # If there is room at the bottom of the list and we're added above the lowest value in the list...
         elsif current_first.rank && current_first.rank > RankedModel::MIN_RANK_VALUE && rank > current_first.rank
           # ...then move everyone else below us down 1 and change our rank down 1 to avoid the collission
           _scope.
             where( instance_class.arel_table[ranker.column].lt(rank) ).
-            update_all( %Q{#{ranker.column} = #{ranker.column} - 1} )
+            update_all( "#{ranker.column} = #{ranker.column} - 1" )
           rank_at( rank - 1 )
         else
           rebalance_ranks

--- a/lib/ranked-model/ranker.rb
+++ b/lib/ranked-model/ranker.rb
@@ -175,10 +175,6 @@ module RankedModel
 
       def rearrange_ranks
         _scope = finder
-        unless instance.id.nil?
-          # Never update ourself, shift others around us.
-          _scope = _scope.where( instance_class.arel_table[instance_class.primary_key].not_eq(instance.id) )
-        end
         # If there is room at the bottom of the list and we're added to the very top of the list...
         if current_first.rank && current_first.rank > RankedModel::MIN_RANK_VALUE && rank == RankedModel::MAX_RANK_VALUE
           # ...then move everyone else down 1 to make room for us at the end

--- a/lib/ranked-model/ranker.rb
+++ b/lib/ranked-model/ranker.rb
@@ -265,7 +265,7 @@ module RankedModel
 
       def current_order
         @current_order ||= begin
-          finder.collect { |ordered_instance|
+          finder.unscope(where: instance_class.primary_key.to_sym).collect { |ordered_instance|
             RankedModel::Ranker::Mapper.new ranker, ordered_instance
           }
         end

--- a/ranked-model.gemspec
+++ b/ranked-model.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.description = %q{ranked-model is a modern row sorting library built for Rails 3 & 4. It uses ARel aggressively and is better optimized than most other libraries.}
   s.license     = 'MIT'
 
-  s.add_dependency "activerecord", ">= 3.2.22.5"
+  s.add_dependency "activerecord", ">= 4.1.16"
   s.add_development_dependency "rspec", "~> 3"
   s.add_development_dependency "rspec-its"
   s.add_development_dependency "mocha"

--- a/ranked-model.gemspec
+++ b/ranked-model.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "database_cleaner", "~> 1.7.0"
   s.add_development_dependency "rake", "~> 10.1.0"
   s.add_development_dependency "appraisal"
+  s.add_development_dependency "pry"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/spec/duck-model/duck_spec.rb
+++ b/spec/duck-model/duck_spec.rb
@@ -260,7 +260,7 @@ describe Duck do
 
       context {
 
-        before { @ducks[:wingy].update_attribute :row_position, :up }
+        before { @ducks[:wingy].update_attribute :row_position, :down }
 
         subject { Duck.ranker(:row).with(Duck.new).current_at_position(@ducks.size - 2).instance }
 

--- a/spec/duck-model/duck_spec.rb
+++ b/spec/duck-model/duck_spec.rb
@@ -246,10 +246,21 @@ describe Duck do
            Duck.where(id: @ducks[name].id).update_all(row: RankedModel::MAX_RANK_VALUE - i)
            @ducks[name].reload
          end
-         @ducks[:wingy].update_attribute :row_position, (@ducks.size - 2) # Second to last position
       }
 
       context {
+
+        before { @ducks[:wingy].update_attribute :row_position, (@ducks.size - 2) }
+
+        subject { Duck.ranker(:row).with(Duck.new).current_at_position(@ducks.size - 2).instance }
+
+        its(:id) { should == @ducks[:wingy].id }
+
+      }
+
+      context {
+
+        before { @ducks[:wingy].update_attribute :row_position, :up }
 
         subject { Duck.ranker(:row).with(Duck.new).current_at_position(@ducks.size - 2).instance }
 

--- a/spec/duck-model/duck_spec.rb
+++ b/spec/duck-model/duck_spec.rb
@@ -239,6 +239,26 @@ describe Duck do
 
     end
 
+    describe "second to last" do
+
+      before {
+        [:quacky, :feathers, :wingy, :webby, :waddly, :beaky].each_with_index do |name, i|
+           Duck.where(id: @ducks[name].id).update_all(row: RankedModel::MAX_RANK_VALUE - i)
+           @ducks[name].reload
+         end
+         @ducks[:wingy].update_attribute :row_position, (@ducks.size - 2) # Second to last position
+      }
+
+      context {
+
+        subject { Duck.ranker(:row).with(Duck.new).current_at_position(@ducks.size - 2).instance }
+
+        its(:id) { should == @ducks[:wingy].id }
+
+      }
+
+    end
+
     describe "at the end" do
 
       before {

--- a/spec/duck-model/lots_of_ducks_spec.rb
+++ b/spec/duck-model/lots_of_ducks_spec.rb
@@ -150,21 +150,23 @@ describe Duck do
     describe "with no more gaps" do
 
       before {
-        @first = Duck.first
-        @second = Duck.where(:row => RankedModel::MAX_RANK_VALUE).first || Duck.offset(1).first
-        @third = Duck.offset(2).first
-        @fourth = Duck.offset(4).first
+        @first = Duck.rank(:row).first
+        @second = Duck.rank(:row).offset(1).first
+        @third = Duck.rank(:row).offset(2).first
+        @fourth = Duck.rank(:row).offset(4).first
+        @fifth = Duck.rank(:row).offset(5).first
         @lower = Duck.rank(:row).
-          where(Duck.arel_table[:id].not_in([@first.id, @second.id, @third.id, @fourth.id])).
+          where(Duck.arel_table[:id].not_in([@first.id, @second.id, @third.id, @fourth.id, @fifth.id])).
           where(Duck.arel_table[:row].lt(RankedModel::MAX_RANK_VALUE / 2)).
           collect {|d| d.id }
         @upper = Duck.rank(:row).
-          where(Duck.arel_table[:id].not_in([@first.id, @second.id, @third.id, @fourth.id])).
+          where(Duck.arel_table[:id].not_in([@first.id, @second.id, @third.id, @fourth.id, @fifth.id])).
           where(Duck.arel_table[:row].gteq(RankedModel::MAX_RANK_VALUE / 2)).
           collect {|d| d.id }
         @first.update_attribute :row, RankedModel::MIN_RANK_VALUE
         @second.update_attribute :row, RankedModel::MAX_RANK_VALUE
         @third.update_attribute :row, (RankedModel::MAX_RANK_VALUE / 2)
+        Duck.where(id: @fifth.id).update_all row: @third.row
         @fourth.update_attribute :row, @third.row
       }
 
@@ -172,7 +174,7 @@ describe Duck do
 
         subject { Duck.rank(:row).collect {|d| d.id } }
 
-        it { is_expected.to eq([@first.id] + @lower + [@fourth.id, @third.id] + @upper + [@second.id]) }
+        it { is_expected.to eq([@first.id] + @lower + [@fourth.id, @third.id, @fifth.id] + @upper + [@second.id]) }
 
       }
 

--- a/spec/duck-model/lots_of_ducks_spec.rb
+++ b/spec/duck-model/lots_of_ducks_spec.rb
@@ -9,6 +9,20 @@ describe Duck do
     end
   }
 
+  describe "a large number of records" do
+    before { @ducks = Duck.all }
+
+    describe "the last two ducks' rows' difference" do
+      subject { @ducks[-1].row - @ducks[-2].row }
+      it { is_expected.not_to be_between(-1, 1) }
+    end
+
+    describe "the second to last two ducks' rows' difference" do
+      subject { @ducks[-2].row - @ducks[-3].row }
+      it { is_expected.not_to be_between(-1, 1) }
+    end
+  end
+
   describe "setting and fetching by position" do
 
     describe '137' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,11 +3,15 @@ require 'bundler/setup'
 require 'rspec/its'
 
 require 'ranked-model'
+require 'pry'
 
 Dir[File.join(File.dirname(__FILE__), 'support/**/*.rb')].each {|f| require f}
 
 # After the DB connection is setup
 require 'database_cleaner'
+
+# Uncomment this to see Active Record logging for tests
+# ActiveRecord::Base.logger = Logger.new(STDOUT)
 
 RSpec.configure do |config|
   config.mock_with :mocha


### PR DESCRIPTION
There's an issue where if we have ranked items with consecutive rank integers right at the top end of the list (i.e. `[..., 2147483646, 2147483647]`) and we try to move an item into the second to last position, the item actually ends up in the last position. The reason is because of this calculation:

 https://github.com/mixonic/ranked-model/blob/bc4c840437dd3f0386e54b5d508c492bc2cb68e6/lib/ranked-model/ranker.rb#L151

Here we can see that the calculation results in us trying to set the rank to the higher rank because the calculation rounds up.

I haven't come up with a solution as of writing this, but I have created a failing test to show the bug.

@mixonic, if you had any quick insights to give that'd be great. I'm thinking that either this calculation needs to change or rebalancing needs to kick in (or both). Right now `rearrangement` appears to kick in, but it still results in the item being last in the list.

Closes: #88
Fixes: #67 