### PR TITLE
Adds methods to find the relative rank of an instance within the ordered list

### DIFF
--- a/Readme.mkd
+++ b/Readme.mkd
@@ -72,6 +72,15 @@ $.ajax({
 });
 ```
 
+If you need to find the rank of an item with respect to other ranked items, you can use the `{column_name}_rank` method on the model instance. `{column_name}` is your resource ranking column.
+
+Following on from our examples above, the `row_order_rank` method will return the position of the duck object in the list with respect to the order defined by the row_order column.
+
+``` ruby
+Duck.rank(:row_order).first.row_order_rank # => 0
+Duck.rank(:row_order).third.row_order_rank # => 2
+```
+
 Complex Use
 -----------
 

--- a/lib/ranked-model.rb
+++ b/lib/ranked-model.rb
@@ -61,6 +61,10 @@ module RankedModel
         end
       end
 
+      define_method "#{ranker.name}_rank" do
+        ranker.with(self).relative_rank
+      end
+
       public "#{ranker.name}_position", "#{ranker.name}_position="
     end
 

--- a/lib/ranked-model/ranker.rb
+++ b/lib/ranked-model/ranker.rb
@@ -73,6 +73,10 @@ module RankedModel
         instance.send "#{ranker.name}_position"
       end
 
+      def relative_rank
+        finder.where("#{ranker.column} < #{rank}").count(:all)
+      end
+
       def rank
         instance.send "#{ranker.column}"
       end

--- a/spec/duck-model/duck_spec.rb
+++ b/spec/duck-model/duck_spec.rb
@@ -10,12 +10,16 @@ describe Duck do
 
   it { expect(subject).to respond_to(:row_position) }
   it { expect(subject).to respond_to(:row_position=) }
+  it { expect(subject).to respond_to(:row_rank) }
   it { expect(subject).to respond_to(:size_position) }
   it { expect(subject).to respond_to(:size_position=) }
+  it { expect(subject).to respond_to(:size_rank) }
   it { expect(subject).to respond_to(:age_position) }
   it { expect(subject).to respond_to(:age_position=) }
+  it { expect(subject).to respond_to(:age_rank) }
   it { expect(subject).to respond_to(:landing_order_position) }
   it { expect(subject).to respond_to(:landing_order_position=) }
+  it { expect(subject).to respond_to(:landing_order_rank) }
 
 end
 
@@ -746,6 +750,33 @@ describe Duck do
 
     end
 
+  end
+
+  describe "fetching rank for an instance" do
+    before {
+      [:quacky, :feathers, :wingy, :webby, :waddly, :beaky].each_with_index do |name, i|
+         Duck.where(id: @ducks[name].id).update_all(row: RankedModel::MAX_RANK_VALUE - i)
+         @ducks[name].reload
+      end
+    }
+
+    context {
+      subject { Duck.find_by(id: @ducks[:beaky]).row_rank }
+
+      it { should == 0 }
+    }
+
+    context {
+      subject { Duck.find_by(id: @ducks[:wingy]).row_rank }
+
+      it { should == 3 }
+    }
+
+    context {
+      subject { Duck.find_by(id: @ducks[:quacky]).row_rank }
+
+      it { should == 5 }
+    }
   end
 
 end


### PR DESCRIPTION
**Purpose of the PR** -

This PR defines a method to fetch the rank of an instance within the ranked-order.

Example -

```
class Duck < ActiveRecord::Base

  include RankedModel

  ranks :row
  ranks :size
end

quacky = Duck.create(name: 'Quacky')
feathers =  Duck.create(name: 'Feathers')
wingy =  Duck.create(name: 'Wingy')
webby =  Duck.create(name: 'Webby')

row_order = [feathers, webby, quacky, wingy].each_with_index { |duck, index| duck.update_attributes!(row_position: index) }
size_order = [wingy, quacky, webby, feathers].each_with_index { |duck, index| duck.update_attributes!(row_position: index) }

```

On the duck instance `feathers`, we can now access the following

`feathers.row_rank` - will return 0
`feathers.size_rank` - will return 3

**Usages for the method** -

With this interface, it will become easier to insert an instance after/before another instance.

For example - 

To insert the duck instance `webby` after the instance `feathers` in the rank order, we can now do the following -

`webby.update_attributes!(row_position:  feather.row_rank + 1)`

**Future Add-Ons** -

Add interfaces like `insert_after` & `insert_before` on the ranked-order