### PR TITLE
Skip-reranking when current_first/current_last is nil

### DIFF
--- a/lib/ranked-model/ranker.rb
+++ b/lib/ranked-model/ranker.rb
@@ -174,24 +174,28 @@ module RankedModel
       end
 
       def assure_unique_position
-        if ( new_record? || rank_changed? )
-          if (rank > RankedModel::MAX_RANK_VALUE) || current_at_rank(rank)
-            rearrange_ranks
-          end
+        if ( new_record? || rank_changed? ) && rearrange_ranks?
+          rearrange_ranks
+        end
+      end
+
+      def rearrange_ranks?
+        return true if rank > RankedModel::MAX_RANK_VALUE
+        _current_at_rank = current_at_rank(rank)
+        return false if _current_at_rank.nil?
+        _current_first = current_first
+        _current_last = current_last
+        if _current_first.nil? || _current_last.nil?
+          instance.logger.warn "[RANKED_MODEL] cannot rearrange ranks current_first=#{_current_first.inspect} current_last=#{_current_last.inspect} current_at_rank=#{_current_at_rank.inspect} instance=#{instance.inspect}"
+          false
+        else
+          true
         end
       end
 
       def rearrange_ranks
         _scope = finder
         escaped_column = ActiveRecord::Base.connection.quote_column_name ranker.column
-        if current_first.nil?
-          instance.logger.warn "[RANKED_MODEL] current_first is nil. Skipping re-ranking of #{instance.model_name.name} column #{escaped_column} #{instance.id}"
-          return
-        end
-        if current_last.nil?
-          instance.logger.warn "[RANKED_MODEL] current_last is nil. Skipping re-ranking of #{instance.model_name.name} column #{escaped_column} #{instance.id}"
-          return
-        end
         # If there is room at the bottom of the list and we're added to the very top of the list...
         if current_first.rank && current_first.rank > RankedModel::MIN_RANK_VALUE && rank == RankedModel::MAX_RANK_VALUE
           # ...then move everyone else down 1 to make room for us at the end

--- a/lib/ranked-model/ranker.rb
+++ b/lib/ranked-model/ranker.rb
@@ -184,6 +184,14 @@ module RankedModel
       def rearrange_ranks
         _scope = finder
         escaped_column = ActiveRecord::Base.connection.quote_column_name ranker.column
+        if current_first.nil?
+          instance.logger.warn "[RANKED_MODEL] current_first is nil. Skipping re-ranking of #{instance.model_name.name} column #{escaped_column} #{instance.id}"
+          return
+        end
+        if current_last.nil?
+          instance.logger.warn "[RANKED_MODEL] current_last is nil. Skipping re-ranking of #{instance.model_name.name} column #{escaped_column} #{instance.id}"
+          return
+        end
         # If there is room at the bottom of the list and we're added to the very top of the list...
         if current_first.rank && current_first.rank > RankedModel::MIN_RANK_VALUE && rank == RankedModel::MAX_RANK_VALUE
           # ...then move everyone else down 1 to make room for us at the end

--- a/spec/duck-model/duck_spec.rb
+++ b/spec/duck-model/duck_spec.rb
@@ -40,10 +40,7 @@ describe Duck do
         patched_duck_ranker.expects(:current_first).returns(nil)
         patched_duck_ranker.expects(:current_at_rank).returns(:something_truthy)
 
-        expect(patched_duck.save).to eq(false)
-        expect(patched_duck.errors.messages).to eq({
-          :age=>["Could not re-rank: current_first not found."]
-        })
+        expect(patched_duck.save).to eq(true)
       end
     end
 

--- a/spec/duck-model/duck_spec.rb
+++ b/spec/duck-model/duck_spec.rb
@@ -24,6 +24,32 @@ describe Duck do
 end
 
 describe Duck do
+  describe "when re-arranging ranks " do
+    context "cannot be re-arranged" do
+
+      it "fails to save" do
+        patched_duck = Duck.new(
+          :name => 'Quacky',
+          :pond => 'Shin',
+          :age_position => 1,
+        )
+        age_ranker = Duck.rankers.detect {|ranker| ranker.name == :age }
+        Duck.expects(:rankers).once.returns([age_ranker])
+        patched_duck_ranker = age_ranker.with(patched_duck)
+        age_ranker.expects(:with).once.returns(patched_duck_ranker)
+        patched_duck_ranker.expects(:current_first).returns(nil)
+        patched_duck_ranker.expects(:current_at_rank).returns(:something_truthy)
+
+        expect(patched_duck.save).to eq(false)
+        expect(patched_duck.errors.messages).to eq({
+          :age=>["Could not re-rank: current_first not found."]
+        })
+      end
+    end
+
+  end
+end
+describe Duck do
 
   before {
     @ducks = {


### PR DESCRIPTION
A take on 'first do no harm' when seeing the occasional

```
NoMethodError: undefined method `rank' for nil:NilClass (Most recent call first)


File /app/vendor/bundle/ruby/2.6.0/gems/ranked-model-0.4.4/lib/ranked-model/ranker.rb line 188 in rearrange_ranks
```

There are various possible strategies for handling a missing 'current_x'
- reset cache and retry
- make a best effort with what we know
- calculate 'freshness' of the current instance and do something when not fresh
  - have a pluggable strategy when no longer fresh
- try to lock the re-reranking

Related
- https://github.com/mixonic/ranked-model/issues/124
- https://github.com/mixonic/ranked-model/pull/117

Work done:
- just the failing test #149
- two commits: 1. failing test, 2. make it pass
  - strategy 1: skip cannot rearrange (this PR).
  - strategy 2: abort save #151
- unrelated misc  #150