### PR TITLE
specify dist to trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false # use newer travis infrastructure
 language: ruby
 cache: bundler
+dist: trusty
 before_install:
   - gem install bundler -v 1.16.1
 before_script:


### PR DESCRIPTION
#152 CI is failing.
It seems that caused by traivis CI default environment change.

https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment
