### PR TITLE
use xenial distribution instead of trusty on travis CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 sudo: false # use newer travis infrastructure
 language: ruby
 cache: bundler
-dist: trusty
+dist: xenial
+services:
+  - mysql
+  - postgresql
 before_install:
   - gem install bundler -v 1.16.1
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ rvm:
   - 2.4.4
   - 2.5.1
   - jruby-9.1.17.0
-  - rbx-4.5
+  - rbx-4.0
 env:
   - DB=sqlite
   - DB=mysql
@@ -49,5 +49,5 @@ matrix:
       gemfile: gemfiles/rails_4_1.gemfile
     - rvm: 2.5.1
       gemfile: gemfiles/rails_4_1.gemfile
-    - rvm: rbx-4.5
+    - rvm: rbx-4.0
       gemfile: gemfiles/rails_5_2.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ rvm:
   - 2.4.4
   - 2.5.1
   - jruby-9.1.17.0
-  - rbx-3.107
+  - rbx-4.5
 env:
   - DB=sqlite
   - DB=mysql
@@ -49,5 +49,5 @@ matrix:
       gemfile: gemfiles/rails_4_1.gemfile
     - rvm: 2.5.1
       gemfile: gemfiles/rails_4_1.gemfile
-    - rvm: rbx-3.107
+    - rvm: rbx-4.5
       gemfile: gemfiles/rails_5_2.gemfile


### PR DESCRIPTION
#154 test failed cause of postgresql server is too old for Rails6.

So I'd like to update distribution of testing on travisCI for future.