### PR TITLE
fix assigned but unused variable warnings

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --color
+--warnings
 --format documentation

--- a/spec/duck-model/column_default_ducks_spec.rb
+++ b/spec/duck-model/column_default_ducks_spec.rb
@@ -22,7 +22,7 @@ describe 'ColumnDefaultDuck' do
 				end
 			}.not_to raise_error
 		ensure
-			ActiveRecord::Base.establish_connection(DB_CONFIG.to_sym)
+			ActiveRecord::Base.establish_connection(ENV['DB'].to_sym)
 		end
 	end
 

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -148,7 +148,7 @@ class MotorBike < Vehicle
 end
 
 class Ego < ActiveRecord::Base
-  primary_key = :alternative_to_id
+  self.primary_key = :alternative_to_id
   include RankedModel
   ranks :size
 end

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -1,9 +1,9 @@
 require 'active_record'
 require 'logger'
 
-ROOT = File.join(File.dirname(__FILE__), '..')
+ROOT = File.join(File.dirname(__FILE__), '..') unless defined?(ROOT)
 
-DB_CONFIG = ENV["DB"] || "sqlite"
+DB_CONFIG = ENV["DB"] || "sqlite" unless defined?(DB_CONFIG)
 
 ActiveRecord::Base.logger = Logger.new('tmp/ar_debug.log')
 ActiveRecord::Base.configurations = YAML::load(IO.read('spec/support/database.yml'))

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -1,13 +1,13 @@
 require 'active_record'
 require 'logger'
 
-ROOT = File.join(File.dirname(__FILE__), '..') unless defined?(ROOT)
-
-DB_CONFIG = ENV["DB"] || "sqlite" unless defined?(DB_CONFIG)
+unless ENV['DB']
+  ENV['DB'] = 'sqlite'
+end
 
 ActiveRecord::Base.logger = Logger.new('tmp/ar_debug.log')
 ActiveRecord::Base.configurations = YAML::load(IO.read('spec/support/database.yml'))
-ActiveRecord::Base.establish_connection(DB_CONFIG.to_sym)
+ActiveRecord::Base.establish_connection(ENV['DB'].to_sym)
 
 ActiveRecord::Schema.define :version => 0 do
   create_table :ducks, :force => true do |t|


### PR DESCRIPTION
Testing with -w option output following warnings:

```
$ bundle exec  rspec -w
./spec/support/active_record.rb:151: warning: assigned but unused variable - primary_key
./spec/support/active_record.rb:4: warning: already initialized constant ROOT
./spec/support/active_record.rb:4: warning: previous definition of ROOT was here
./spec/support/active_record.rb:6: warning: already initialized constant DB_CONFIG
./spec/support/active_record.rb:6: warning: previous definition of DB_CONFIG was here
```

This warning means primary_key is considered just variable not "#primary_key=" method.
So calling it with `self.` is required.
