### PR TITLE
Support unique indexes when rebalancing ranks

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -4,6 +4,7 @@ appraise "rails-4-2" do
   end
   group :mysql do
     gem "mysql2", "~> 0.4.0", platform: :ruby
+    gem "jdbc-mysql", "~> 5.1.47", platform: :jruby
     gem "activerecord-jdbcmysql-adapter", "~> 1.3.24", platform: :jruby
   end
   group :postgresql do

--- a/gemfiles/rails_4_2.gemfile
+++ b/gemfiles/rails_4_2.gemfile
@@ -16,6 +16,7 @@ end
 
 group :mysql do
   gem "mysql2", "~> 0.4.0", platform: :ruby
+  gem "jdbc-mysql", "~> 5.1.47", platform: :jruby
   gem "activerecord-jdbcmysql-adapter", "~> 1.3.24", platform: :jruby
 end
 

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -21,6 +21,8 @@ ActiveRecord::Schema.define :version => 0 do
     t.string :pond
   end
 
+  add_index :ducks, [:landing_order, :lake_id, :flock_id], unique: true
+
   create_table :wrong_scope_ducks, :force => true do |t|
     t.string :name
     t.integer :size


### PR DESCRIPTION
The goal of this PR is to improve support for apps having a unique index on their ranked columns.

The problem we were seeing in our app is that rebalancing would fail if it attempted to move a record to a position that is already in use (see the example in specs).

I went with the simplest approach possible: see if the target value already exists and if it does, decrement the value until we find an available one. I believe it's reasonable to expect there is always breathing room available for us to work with. E.g. given a million records, the gap used for rebalancing is 4295. 

Eager to hear your thoughts!