### PR TITLE
Test with Ruby 2.7, let Travis pick latest Ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,11 @@ gemfile:
   - gemfiles/rails_6_0.gemfile
 matrix:
   exclude:
+    # Ruby 2.7 uses a `bigdecimal` version that doesn't support BigDecimal.new
+    # that Rails 4.2 uses. See also:
+    # https://github.com/ruby/bigdecimal#which-version-should-you-select
+    - rvm: 2.7
+      gemfile: gemfiles/rails_4_2.gemfile
     - rvm: jruby-9.1.17.0
       gemfile: gemfiles/rails_5_2.gemfile
     - rvm: 2.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 cache: bundler
-sudo: false
 before_install:
   - gem update --system
   - gem install bundler
@@ -8,9 +7,10 @@ before_script:
   - mysql -e 'create database ranked_model_test;'
   - psql -c 'create database ranked_model_test;' -U postgres
 rvm:
-  - 2.4.4
-  - 2.5.1
-  - 2.6.4
+  - 2.4
+  - 2.5
+  - 2.6
+  - 2.7
   - jruby-9.1.17.0
 env:
   - DB=sqlite
@@ -29,7 +29,7 @@ matrix:
   exclude:
     - rvm: jruby-9.1.17.0
       gemfile: gemfiles/rails_5_2.gemfile
-    - rvm: 2.4.4
+    - rvm: 2.4
       gemfile: gemfiles/rails_6_0.gemfile
     - rvm: jruby-9.1.17.0
       gemfile: gemfiles/rails_6_0.gemfile

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ group :sqlite do
 end
 
 group :postgresql do
-  gem "pg", "~> 1.1.4", platform: :ruby
+  gem "pg", "~> 1.2.0", platform: :ruby
 end
 
 group :mysql do

--- a/Readme.mkd
+++ b/Readme.mkd
@@ -5,7 +5,7 @@
 Installation
 ------------
 
-ranked-model passes specs with Rails 4.2, 5.0, 5.1, 5.2 and 6.0 for MySQL, Postgres, and SQLite on Ruby 2.4 through 2.6, and jruby-9.1.17.0 where Rails supports the platform. Note that the `pg` gem has pulled support for rbx (Rubinius) from version 1 onward.
+ranked-model passes specs with Rails 4.2, 5.0, 5.1, 5.2 and 6.0 for MySQL, Postgres, and SQLite on Ruby 2.4 through 2.7, and jruby-9.1.17.0 where Rails supports the platform. Note that the `pg` gem has pulled support for rbx (Rubinius) from version 1 onward.
 
 To install ranked-model, just add it to your `Gemfile`:
 

--- a/gemfiles/rails_5_0.gemfile
+++ b/gemfiles/rails_5_0.gemfile
@@ -10,7 +10,7 @@ group :sqlite do
 end
 
 group :postgresql do
-  gem "pg", "~> 1.1.4", platform: :ruby
+  gem "pg", "~> 1.2.0", platform: :ruby
   gem "activerecord-jdbcpostgresql-adapter", "~> 50.0", platform: :jruby
 end
 

--- a/gemfiles/rails_5_1.gemfile
+++ b/gemfiles/rails_5_1.gemfile
@@ -10,7 +10,7 @@ group :sqlite do
 end
 
 group :postgresql do
-  gem "pg", "~> 1.1.4", platform: :ruby
+  gem "pg", "~> 1.2.0", platform: :ruby
   gem "activerecord-jdbcpostgresql-adapter", "~> 51.0", platform: :jruby
 end
 

--- a/gemfiles/rails_5_2.gemfile
+++ b/gemfiles/rails_5_2.gemfile
@@ -10,7 +10,7 @@ group :sqlite do
 end
 
 group :postgresql do
-  gem "pg", "~> 1.1.4", platform: :ruby
+  gem "pg", "~> 1.2.0", platform: :ruby
   gem "activerecord-jdbcpostgresql-adapter", "~> 52.0", platform: :jruby
 end
 

--- a/gemfiles/rails_6_0.gemfile
+++ b/gemfiles/rails_6_0.gemfile
@@ -10,7 +10,7 @@ group :sqlite do
 end
 
 group :postgresql do
-  gem "pg", "~> 1.1.4", platform: :ruby
+  gem "pg", "~> 1.2.0", platform: :ruby
   gem "activerecord-jdbcpostgresql-adapter", "~> 60.0", platform: :jruby
 end
 


### PR DESCRIPTION
I know there is #162, but it seems stale. So for the moment this seems like an easy change to verify everything works with latest Rubies.

Edit: It seems GitHub checks and Travis are somehow not working together right now, @mixonic, could you maybe look into it? The PRs are still being built, there's just no report on GitHub. https://travis-ci.org/github/mixonic/ranked-model/pull_requests