### PR TITLE
Fix an SQL syntax error in Ranker#relative_rank

### DIFF
--- a/lib/ranked-model/ranker.rb
+++ b/lib/ranked-model/ranker.rb
@@ -78,7 +78,9 @@ module RankedModel
       end
 
       def relative_rank
-        finder.where("#{ranker.column} < #{rank}").count(:all)
+        escaped_column = ActiveRecord::Base.connection.quote_column_name ranker.column
+
+        finder.where("#{escaped_column} < #{rank}").count(:all)
       end
 
       def rank

--- a/lib/ranked-model/ranker.rb
+++ b/lib/ranked-model/ranker.rb
@@ -78,7 +78,7 @@ module RankedModel
       end
 
       def relative_rank
-        escaped_column = ActiveRecord::Base.connection.quote_column_name ranker.column
+        escaped_column = instance_class.connection.quote_column_name ranker.column
 
         finder.where("#{escaped_column} < #{rank}").count(:all)
       end
@@ -189,7 +189,7 @@ module RankedModel
 
       def rearrange_ranks
         _scope = finder
-        escaped_column = ActiveRecord::Base.connection.quote_column_name ranker.column
+        escaped_column = instance_class.connection.quote_column_name ranker.column
         # If there is room at the bottom of the list and we're added to the very top of the list...
         if current_first.rank && current_first.rank > RankedModel::MIN_RANK_VALUE && rank == RankedModel::MAX_RANK_VALUE
           # ...then move everyone else down 1 to make room for us at the end

--- a/spec/number-model/number_spec.rb
+++ b/spec/number-model/number_spec.rb
@@ -28,4 +28,12 @@ describe Number do
 
   end
 
+  describe "getting a position with keyword column name" do
+
+    subject { Number.first }
+
+    its(:order_rank) { should == 0 }
+
+  end
+
 end


### PR DESCRIPTION
The following error occurred when using the `order` column and calling the `model.order_rank` method:

```
ActiveRecord::StatementInvalid:
  PG::SyntaxError: ERROR:  syntax error at or near "order"
  LINE 1: ... FROM "numbers" WHERE ("numbers"."id" != $1) AND (order < -2...
                                                               ^
  : SELECT COUNT(*) FROM "numbers" WHERE ("numbers"."id" != $1) AND (order < -2123884926)
```